### PR TITLE
Add grid overlay options to CLI with usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,30 @@ Downloading & extracting `minimap-without-markers.zip`…
 ######################################################################## 100.0%
 ```
 
+Use the `--grid` option if you want the maps with grid overlay and markers:
+
+```
+$ ./install-tibia-maps --grid
+Downloading & extracting `minimap-with-grid-overlay-and-markers.zip`…
+######################################################################## 100.0%
+```
+
+Use the `--grid-no-markers` option if you want the maps with grid overlay but without markers:
+
+```
+$ ./install-tibia-maps --grid-no-markers
+Downloading & extracting `minimap-with-grid-overlay-without-markers.zip`…
+######################################################################## 100.0%
+```
+
+Use the `--grid-poi-markers` option if you want the maps with grid overlay and POI markers:
+
+```
+$ ./install-tibia-maps --grid-poi-markers
+Downloading & extracting `minimap-with-grid-overlay-and-poi-markers.zip`…
+######################################################################## 100.0%
+```
+
 Example cron job to update the maps daily at midnight:
 
 ```cron

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ curl https://raw.githubusercontent.com/tibiamaps/tibia-maps-installer-macos/main
 
 ## Usage
 
+Use `--help` to list the available options:
+
+```
+$ ./install-tibia-maps --help
+Usage: install-tibia-maps [--help|--no-markers|--grid|--grid-no-markers|--grid-poi-markers]
+```
+
 By default, `install-tibia-maps` installs the Tibia maps files with markers included:
 
 ```

--- a/install-tibia-maps
+++ b/install-tibia-maps
@@ -2,13 +2,28 @@
 
 DEST_DIR="${HOME}/Library/Application Support/CipSoft GmbH/Tibia/packages/Tibia.app/Contents/Resources";
 mkdir -p "${DEST_DIR}";
-if [ "${1}" = '--no-markers' ]; then
-	echo 'Downloading & extracting `minimap-without-markers.zip`…';
-	url='https://tibiamaps.io/downloads/minimap-without-markers';
-else
-	echo 'Downloading & extracting `minimap-with-markers.zip`…';
-	url='https://tibiamaps.io/downloads/minimap-with-markers';
-fi;
+case "${1}" in
+	--grid)
+		echo 'Downloading & extracting `minimap-with-grid-overlay-and-markers.zip`…';
+		url='https://tibiamaps.io/downloads/minimap-with-grid-overlay-and-markers';
+		;;
+	--grid-no-markers)
+		echo 'Downloading & extracting `minimap-with-grid-overlay-without-markers.zip`…';
+		url='https://tibiamaps.io/downloads/minimap-with-grid-overlay-without-markers';
+		;;
+	--no-markers)
+		echo 'Downloading & extracting `minimap-without-markers.zip`…';
+		url='https://tibiamaps.io/downloads/minimap-without-markers';
+		;;
+	--grid-poi-markers)
+		echo 'Downloading & extracting `minimap-with-grid-overlay-and-poi-markers.zip`…';
+		url='https://tibiamaps.io/downloads/minimap-with-grid-overlay-and-poi-markers';
+		;;
+	*)
+		echo 'Downloading & extracting `minimap-with-markers.zip`…';
+		url='https://tibiamaps.io/downloads/minimap-with-markers';
+		;;
+esac;
 zip_file_name="$(mktemp -t 'minimap-XXXXXX')";
 curl --progress-bar --location "${url}" > "${zip_file_name}";
 unzip -o -d "${DEST_DIR}" "${zip_file_name}";

--- a/install-tibia-maps
+++ b/install-tibia-maps
@@ -1,29 +1,47 @@
 #!/usr/bin/env bash
 
+usage() {
+	echo 'Usage: install-tibia-maps [--help|--no-markers|--grid|--grid-no-markers|--grid-poi-markers]';
+}
+
+if [ "$#" -gt 1 ]; then
+	usage >&2;
+	exit 1;
+fi;
+
 DEST_DIR="${HOME}/Library/Application Support/CipSoft GmbH/Tibia/packages/Tibia.app/Contents/Resources";
+if [ "$#" -eq 0 ]; then
+	echo 'Downloading & extracting `minimap-with-markers.zip`…';
+	url='https://tibiamaps.io/downloads/minimap-with-markers';
+else
+	case "${1}" in
+		--help)
+			usage;
+			exit 0;
+			;;
+		--grid)
+			echo 'Downloading & extracting `minimap-with-grid-overlay-and-markers.zip`…';
+			url='https://tibiamaps.io/downloads/minimap-with-grid-overlay-and-markers';
+			;;
+		--grid-no-markers)
+			echo 'Downloading & extracting `minimap-with-grid-overlay-without-markers.zip`…';
+			url='https://tibiamaps.io/downloads/minimap-with-grid-overlay-without-markers';
+			;;
+		--no-markers)
+			echo 'Downloading & extracting `minimap-without-markers.zip`…';
+			url='https://tibiamaps.io/downloads/minimap-without-markers';
+			;;
+		--grid-poi-markers)
+			echo 'Downloading & extracting `minimap-with-grid-overlay-and-poi-markers.zip`…';
+			url='https://tibiamaps.io/downloads/minimap-with-grid-overlay-and-poi-markers';
+			;;
+		*)
+			usage >&2;
+			exit 1;
+			;;
+	esac;
+fi;
 mkdir -p "${DEST_DIR}";
-case "${1}" in
-	--grid)
-		echo 'Downloading & extracting `minimap-with-grid-overlay-and-markers.zip`…';
-		url='https://tibiamaps.io/downloads/minimap-with-grid-overlay-and-markers';
-		;;
-	--grid-no-markers)
-		echo 'Downloading & extracting `minimap-with-grid-overlay-without-markers.zip`…';
-		url='https://tibiamaps.io/downloads/minimap-with-grid-overlay-without-markers';
-		;;
-	--no-markers)
-		echo 'Downloading & extracting `minimap-without-markers.zip`…';
-		url='https://tibiamaps.io/downloads/minimap-without-markers';
-		;;
-	--grid-poi-markers)
-		echo 'Downloading & extracting `minimap-with-grid-overlay-and-poi-markers.zip`…';
-		url='https://tibiamaps.io/downloads/minimap-with-grid-overlay-and-poi-markers';
-		;;
-	*)
-		echo 'Downloading & extracting `minimap-with-markers.zip`…';
-		url='https://tibiamaps.io/downloads/minimap-with-markers';
-		;;
-esac;
 zip_file_name="$(mktemp -t 'minimap-XXXXXX')";
 curl --progress-bar --location "${url}" > "${zip_file_name}";
 unzip -o -d "${DEST_DIR}" "${zip_file_name}";


### PR DESCRIPTION
Add command-line flags to allow users to download maps with different grid and marker configurations:
- `--grid`: maps with grid overlay and markers
- `--grid-no-markers`: maps with grid overlay without markers
- `--grid-poi-markers`: maps with grid overlay and POI markers

Similar to what is available with Linux installer: [https://github.com/tibiamaps/tibia-maps-installer-linux/blob/main/install-tibia-maps](https://github.com/tibiamaps/tibia-maps-installer-linux/blob/main/install-tibia-maps)

This I suggested in issue: https://github.com/tibiamaps/tibia-maps-installer-macos/issues/2